### PR TITLE
add multiple grammar scope names support

### DIFF
--- a/lib/stylus-autocompile.js
+++ b/lib/stylus-autocompile.js
@@ -21,12 +21,12 @@ export function deactivate() {
   disposable = null;
 }
 
-const stylusGrammar = atom.grammars.grammarForScopeName('source.stylus');
+const stylusGrammars = ['source.stylus', 'source.css.stylus'].map(scopeName => atom.grammars.grammarForScopeName(scopeName));
 
 function handleSave(textEditorElement) {
   if(typeof textEditorElement.getModel != 'function') return;
   var textEditor = textEditorElement.getModel();
-  if(textEditor.getGrammar() == stylusGrammar) {
+  if(stylusGrammars.indexOf(textEditor.getGrammar()) > -1) {
     compile(textEditor.getText(), textEditor.getURI());
   }
 }


### PR DESCRIPTION
Hello !

Since [language-stylus](https://github.com/matthojo/language-stylus) package upgraded to 2.*, they changed their grammar scope name ('source.stylus' became 'source.css.stylus').

I updated language-stylus and stylus-autocompile was not working anymore on .styl files, since it's relying on grammar.

I suggested a way to use multiple grammars (for those who still are in 1.\* with language-stylus package).

Let me know if it works for you !
